### PR TITLE
Clean Up Warnings in Initial Files

### DIFF
--- a/ConfigManager.cs
+++ b/ConfigManager.cs
@@ -1,14 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.Json;
-using System.Threading.Tasks;
+﻿using System.Text.Json;
 
 namespace scrbl
 {
     internal class ConfigManager
     {
+        private static readonly JsonSerializerOptions s_writeOptions = new() { WriteIndented = true };
+
         private static readonly string ConfigPath = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
             "scrbl",
@@ -19,9 +16,9 @@ namespace scrbl
             var fullNotesPath = Path.Combine(path, "scrbl.md");
 
             var config = new { NotesFilePath = fullNotesPath };
-            var json = JsonSerializer.Serialize(config, new JsonSerializerOptions { WriteIndented = true });
-
-            Directory.CreateDirectory(Path.GetDirectoryName(ConfigPath));
+            var json = JsonSerializer.Serialize(config, s_writeOptions);
+            var configDir = Path.GetDirectoryName(ConfigPath) ?? throw new InvalidOperationException("Could not determine config directory.");
+            Directory.CreateDirectory(configDir);
 
             Directory.CreateDirectory(path);
 
@@ -43,7 +40,9 @@ namespace scrbl
 
             var json = File.ReadAllText(ConfigPath);
             var config = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
-            return config["NotesFilePath"];
+            return  (config == null || !config.ContainsKey("NotesFile"))
+                ? throw new InvalidOperationException("Invalid configuration file")
+                : config["NotesFilePath"];
         }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -1,20 +1,10 @@
 ﻿using scrbl;
-using System.CommandLine;
 
 internal class Program
 {
     static void Main(string[] args)
     {
-        var cli = new ScrblCli();
-        cli.Run(args);
-
-        /**
-         * These will add as a new bullet
-         * PUT IN DSU -d
-         * PUT IN SUMMARY -s
-         * PUT IN TOP-LEVEL (no flag)
-         * using the -f flag will open full editor
-         * 
-         */
+        _ = new ScrblCli();
+        ScrblCli.Run(args);
     }
 }

--- a/ScrblCli.cs
+++ b/ScrblCli.cs
@@ -1,26 +1,21 @@
-﻿using System;
-using System.Collections.Generic;
-using System.CommandLine;
-using System.Configuration;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.IO;
+﻿using System.CommandLine;
 
 namespace scrbl
 {
     internal class ScrblCli
     {
-        public int Run(string[] args)
+        public static int Run(string[] args)
         {
             var rootcommand = BuildRootCommand();
             return rootcommand.Parse(args).Invoke();
         }
 
-        private RootCommand BuildRootCommand()
+        private static RootCommand BuildRootCommand()
         {
-            var rootCommand = new RootCommand("Scrbl");
-            rootCommand.Add(SetupCommand());
+            var rootCommand = new RootCommand("Scrbl")
+            {
+                SetupCommand()
+            };
             return rootCommand;
         }
 
@@ -56,6 +51,5 @@ namespace scrbl
 
             return command;
         }
-
     }
 }


### PR DESCRIPTION
`ConfigManger.cs` 
- create static `JsonSerializerOptions` to get rid of warning
- add some error handling for config and notes files

`Program.cs`
- cleaned up comments and usings

`ScrblCli.cs`
- cleaned up `Run` and `BuildRootCommand` functionsd