### PR TITLE
Migrate to Spectre.Console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,5 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+*.idea

--- a/scrbl.csproj
+++ b/scrbl.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Spectre.Console" Version="0.50.1-preview.0.20" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta5.25306.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.6" />
   </ItemGroup>


### PR DESCRIPTION
To make the experience of a cli better this PR uses the Spectre.console package instead of the System.Console package